### PR TITLE
Test r version support

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ URL: https://github.com/markowetzlab/CINSignatureQuantification
 BugReports: https://github.com/markowetzlab/CINSignatureQuantification/issues
 biocViews: 
 Depends:
-    R (>= 4.0.0)
+    R (>= 3.6.0)
 Imports:
     base,
     Biobase (>= 2.46.0),

--- a/R/createCNQuant.R
+++ b/R/createCNQuant.R
@@ -61,19 +61,22 @@ createCNQuant <- function(data=NULL,experimentName = "defaultExperiment",build =
                           experimentName = experimentName))
     } else if(is.data.frame(data)){
         header <- colnames(data)
-        if(!any(header == c("chromosome","start","end","segVal","sample"))){
-            stop("Header does not match the required naming")
+        if(!all(header %in% c("chromosome","start","end","segVal","sample"))){
+            stop("Header does not match the required naming ['chromosome','start','end','segVal','sample']")
         }
         segTable <- data
         if(checkSegValRounding(segTable$segVal)){
-            warning("segVal appears to be rounded, copy number signatures require unrounded absolute copy numbers")
+            warning("segVal appears to be rounded, copy number signatures were defined on unrounded absolute copy numbers, use caution when interpretting and comparing between rounded and unrounded inputs.")
         }
-        if(checkbinned(segTable)){
-            #segTable <- getSegTable()
-            #split(segTable,f = as.factor(segTable$sample))
-        } else {
-            segTable <- split(segTable,f = as.factor(segTable$sample))
-        }
+        ## Binned inputs (fixed width not supported yet)
+        # if(checkbinned(segTable)){
+        #     #segTable <- getSegTable()
+        #     #split(segTable,f = as.factor(segTable$sample))
+        # } else {
+        #     segTable <- split(segTable,f = as.factor(segTable$sample))
+        # }
+        ## Temp split until fixed bin input implemented
+        segTable <- split(segTable,f = as.factor(segTable$sample))
         samplefeatData <- generateSampleFeatData(x = segTable)
         methods::new("CNQuant",segments=segTable,samplefeatData = samplefeatData,
                      ExpData = methods::new("ExpQuant",


### PR DESCRIPTION
Major:
- Updates package to allow for lower versions of R `>3.6.0` instead of R `>4.0.0`.

Minor:
- Restores `.gitingnore` and `.Rbuildignore`
- Fixes incorrect detection of header specification to correctly trigger an error when file contains incorrect or mislabeled input column names.
- Temporary removal of unsupported binned genome input type (to be re-implemented)