### PR TITLE
checkChromosomeFormat-fix

### DIFF
--- a/R/checkChromosomeFormat.R
+++ b/R/checkChromosomeFormat.R
@@ -3,7 +3,7 @@ checkChromosomeFormat <- function(x=NULL){
     if(is.null(x)){
         stop("no chromosome col")
     }
-    chrs <- c(seq.int(1:22),c("X"))
+
     # Catch chr prefix
     if(any(grepl(pattern = "chr",x = x))){
         message("checkChromosomeFormat: dropping 'chr' prefix")
@@ -15,12 +15,5 @@ checkChromosomeFormat <- function(x=NULL){
         x[x=="23"] <- "X"
         x[x=="24"] <- "Y"
     }
-
-    if(any(!x %in% chrs)){
-        message("checkChromosomeFormat: dropping unsupported chromsomes")
-        x <- x[x %in% chrs]
-    }
-    # return
-    x <- as.factor(x)
     return(x)
 }

--- a/R/createCNQuant.R
+++ b/R/createCNQuant.R
@@ -73,8 +73,9 @@ createCNQuant <- function(data=NULL,experimentName = "defaultExperiment",build =
             #     segTable <- split(segTable,f = as.factor(segTable$sample))
             # }
             ## Temp split until fixed bin input implemented
-            segTable <- droplevels(segTable)
             segTable$chromosome <- checkChromosomeFormat(segTable$chromosome)
+            segTable <- dropChromosomes(segTable)
+            segTable <- droplevels(segTable)
             segTable <- split(segTable,f = as.factor(segTable$sample))
 
             samplefeatData <- generateSampleFeatData(x = segTable)
@@ -92,8 +93,9 @@ createCNQuant <- function(data=NULL,experimentName = "defaultExperiment",build =
                     defined on unrounded absolute copy numbers, use caution when
                     interpretting and comparing between rounded and unrounded inputs.")
         }
-        segTable <- droplevels(segTable)
         segTable$chromosome <- checkChromosomeFormat(segTable$chromosome)
+        segTable <- dropChromosomes(segTable)
+        segTable <- droplevels(segTable)
         segTable <- split(segTable,f = as.factor(segTable$sample))
         samplefeatData <- generateSampleFeatData(x = segTable)
         methods::new("CNQuant",segments = segTable,samplefeatData = samplefeatData,
@@ -121,8 +123,9 @@ createCNQuant <- function(data=NULL,experimentName = "defaultExperiment",build =
         #     segTable <- split(segTable,f = as.factor(segTable$sample))
         # }
         ## Temp split until fixed bin input implemented
-        segTable <- droplevels(segTable)
         segTable$chromosome <- checkChromosomeFormat(segTable$chromosome)
+        segTable <- dropChromosomes(segTable)
+        segTable <- droplevels(segTable)
         segTable <- split(segTable,f = as.factor(segTable$sample))
         samplefeatData <- generateSampleFeatData(x = segTable)
         methods::new("CNQuant",segments=segTable,samplefeatData = samplefeatData,

--- a/R/dropChromosomes.R
+++ b/R/dropChromosomes.R
@@ -4,7 +4,7 @@ dropChromosomes <- function(x=NULL){
     }
     chrs <- c(seq.int(1:22),c("X"))
     if(any(!x$chromosome %in% chrs)){
-        message("checkChromosomeFormat: dropping unsupported chromsomes")
+        message("dropChromosomes: dropping unsupported chromsomes")
         x <- x[x$chromosome %in% chrs,]
     }
     x$chromosome <- factor(x$chromosome,levels=chrs)

--- a/R/dropChromosomes.R
+++ b/R/dropChromosomes.R
@@ -1,0 +1,12 @@
+dropChromosomes <- function(x=NULL){
+    if(is.null(x)){
+        stop("no seg table")
+    }
+    chrs <- c(seq.int(1:22),c("X"))
+    if(any(!x$chromosome %in% chrs)){
+        message("checkChromosomeFormat: dropping unsupported chromsomes")
+        x <- x[x$chromosome %in% chrs,]
+    }
+    x$chromosome <- factor(x$chromosome,levels=chrs)
+    return(x)
+}

--- a/R/plotActivities.R
+++ b/R/plotActivities.R
@@ -89,7 +89,9 @@ plotActivities <- function(object,type="threshold",cols=NULL){
     clms <- 1
     l.pos <- -0.1
 
-    plotdata <- plotdata[order(plotdata[,1],decreasing = T),]
+    if(nrow(plotdata) > 1){
+        plotdata <- plotdata[order(plotdata[,1],decreasing = T),]
+    }
     tabl <- t(as.matrix(plotdata))
 
     graphics::par(mar=c(5, 4, 4, 8), xpd=TRUE)

--- a/tests/testthat/test-checkChromosomeFormat.R
+++ b/tests/testthat/test-checkChromosomeFormat.R
@@ -1,0 +1,9 @@
+test_that("checkChromosomeFormat", {
+    chrs <- c(seq.int(1:22),c("X"))
+    chrs_chr <- c(paste0("chr",c(seq.int(1:22),c("X"))))
+    chrs_num <- c(seq.int(1:23))
+
+    expect_equal(checkChromosomeFormat(chrs),chrs)
+    expect_equal(checkChromosomeFormat(chrs_chr),chrs)
+    expect_equal(checkChromosomeFormat(chrs_num),chrs)
+})

--- a/tests/testthat/test-dropChromosomes.R
+++ b/tests/testthat/test-dropChromosomes.R
@@ -1,0 +1,11 @@
+test_that("dropChromosomes", {
+  chrs <- c(seq.int(1:22),c("X"))
+  d <- data.frame(chromosome=c("1","2","Y","mt"),
+                  start=c(1,1,1,1),
+                  end=c(2,2,2,2),
+                  segVal=c(1,2,3,4),
+                  sample=c("s1","s1","s1","s1"))
+  t <- d[d$chromosome %in% c("1","2"),]
+  t$chromosome <- factor(t$chromosome,levels = chrs)
+  expect_equal(dropChromosomes(d),t)
+})


### PR DESCRIPTION
Implementing a fix for checkChrosomosomeFormat incorrectly handling Y chromosomes. Inclusion of additional function to drop unsupported chromosomes after formatting. Minor fix to plotting a single stacked activity bar plot.