### PR TITLE
Bug - calculateSXC feature osCN zero count

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CINSignatureQuantification
 Title: Simple and quick measuring of copy number signatures in cancers
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: 
     c(person(given = "Philip S",
            family = "Smith",

--- a/R/calculateSampleByComponentMatrixDrews.R
+++ b/R/calculateSampleByComponentMatrixDrews.R
@@ -32,7 +32,13 @@ calculateSampleByComponentMatrixDrews = function(brECNF, UNINFPRIOR = TRUE) {
         }
 
         # Normalise densities to probabilities
-        postDatScaled = data.frame( postDatUnscaled / rowSums(postDatUnscaled) )
+        ## Added fix for circumstances where zero osCN features are recorded
+        ## Should also be applicable to other features - CINSignaturesQuantification issue #17
+        if(is.null(dim(postDatUnscaled))){
+            postDatScaled = data.frame(t(postDatUnscaled / sum(postDatUnscaled)))
+        } else {
+            postDatScaled = data.frame(postDatUnscaled / rowSums(postDatUnscaled))
+        }
         postDatScaled$Sample = thisEcnf[,1]
         matSxC = stats::aggregate(. ~ Sample, postDatScaled, sum)
         rownames(matSxC) = matSxC$Sample

--- a/R/calculateSampleByComponentMatrixMac.R
+++ b/R/calculateSampleByComponentMatrixMac.R
@@ -38,7 +38,13 @@ calculateSampleByComponentMatrixMac = function(brECNF, UNINFPRIOR = FALSE) {
         }
 
         # Normalise densities to probabilities
-        postDatScaled = data.frame( postDatUnscaled / rowSums(postDatUnscaled) )
+        ## Added fix for circumstances where zero osCN features are recorded
+        ## Should also be applicable to other features - CINSignaturesQuantification issue #17
+        if(is.null(dim(postDatUnscaled))){
+            postDatScaled = data.frame(t(postDatUnscaled / sum(postDatUnscaled)))
+        } else {
+            postDatScaled = data.frame(postDatUnscaled / rowSums(postDatUnscaled))
+        }
         postDatScaled$Sample = thisEcnf[,1]
         matSxC = stats::aggregate(. ~ Sample, postDatScaled, sum)
         rownames(matSxC) = matSxC$Sample


### PR DESCRIPTION
Fixed bug reported in profiles where osCN count was zero (profiles with incorrect or no segmentation changes). Closes #17 .